### PR TITLE
Update build scripts and target platforms to x64/ARM64

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,0 @@
-dotnet build .\src\IPAbuyer.csproj

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+dotnet build .\src\IPAbuyer.csproj /p:Platform=x64

--- a/run.cmd
+++ b/run.cmd
@@ -1,1 +1,1 @@
-.\src\bin\Debug\net9.0-windows10.0.19041.0\IPAbuyer.exe
+.\src\bin\x64\Debug\net9.0-windows10.0.19041.0\win-x64\IPAbuyer.exe

--- a/src/App.xaml
+++ b/src/App.xaml
@@ -12,27 +12,9 @@
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"/>
             </ResourceDictionary.MergedDictionaries>
-
-            <x:String x:Key="GlobalFontFamily">Microsoft YaHei UI, Microsoft YaHei, Segoe UI</x:String>
-
-            <Style TargetType="TextBlock" BasedOn="{StaticResource DefaultTextBlockStyle}">
-                <Setter Property="FontFamily" Value="{StaticResource GlobalFontFamily}"/>
-            </Style>
-
-            <Style TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
-                <Setter Property="FontFamily" Value="{StaticResource GlobalFontFamily}"/>
-            </Style>
-
-            <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
-                <Setter Property="FontFamily" Value="{StaticResource GlobalFontFamily}"/>
-            </Style>
-
-            <Style TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
-                <Setter Property="FontFamily" Value="{StaticResource GlobalFontFamily}"/>
-            </Style>
-
-            <Style TargetType="ContentDialog" BasedOn="{StaticResource DefaultContentDialogStyle}">
-                <Setter Property="FontFamily" Value="{StaticResource GlobalFontFamily}"/>
+            
+            <Style TargetType="TextBlock">
+                <Setter Property="FontFamily" Value="Microsoft YaHei UI, Microsoft YaHei, Segoe UI"/>
             </Style>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -1,9 +1,11 @@
+using IPAbuyer.Data;
+using IPAbuyer.Views;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using System;
-using IPAbuyer.Views;
-using IPAbuyer.Data;
 
 namespace IPAbuyer
 {
@@ -16,6 +18,7 @@ namespace IPAbuyer
             // 初始化数据库
             PurchasedAppDb.InitDb();
             AccountHistoryDb.InitDb();
+            
             this.InitializeComponent();
         }
 

--- a/src/IPAbuyer.csproj
+++ b/src/IPAbuyer.csproj
@@ -18,15 +18,15 @@
 
         <!-- App Options -->
         <UseRidGraph>true</UseRidGraph>
-        <Platforms>x86;x64;ARM64</Platforms>
+        <Platforms>x64;ARM64</Platforms>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <PublishProfile>win-$(Platform).pubxml</PublishProfile>
         <RuntimeIdentifiers
             Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">
-            win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+            win-x64;win-arm64</RuntimeIdentifiers>
         <RuntimeIdentifiers
             Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">
-            win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+            win10-x64;win10-arm64</RuntimeIdentifiers>
     </PropertyGroup>
     <ItemGroup>
         <None Remove="Views\Settings.xaml" />


### PR DESCRIPTION
Replaced build.cmd with build.ps1 to specify x64 platform for builds. Updated run.cmd to use x64 output path. Simplified font style definitions in App.xaml. Adjusted IPAbuyer.csproj to remove x86 platform and runtime identifiers, now targeting only x64 and ARM64. Minor code cleanup in App.xaml.cs.